### PR TITLE
m keyword highlight added, brackets highlights style updated

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -517,7 +517,9 @@ module.exports = grammar({
     _new_line: $ => /\r?\n/,
 
     // Miscellaneous
-    identifier: $ => token(prec(0, /[a-zA-Z_][a-zA-Z0-9_]*/))
+    identifier: $ => choice($.m, $.regular_identifier),
+    m: $ => /m/i,
+    regular_identifier: $ => token(prec(0, /[a-zA-Z_][a-zA-Z0-9_]*/)),
   }
 });
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -128,6 +128,7 @@
 (comment) @comment
 
 ; Punctuation
+
 [
   "("
   ")"
@@ -135,10 +136,11 @@
   "]"
   "{"
   "}"
+ ] @punctuation.bracket
+[
   "."
   ","
   "?."
-  "?["
  ] @punctuation.delimiter
 
 ; Special highlights for library statements
@@ -175,3 +177,4 @@
   ] @operator)
 
 (as) @keyword
+(m) @keyword


### PR DESCRIPTION
Hi. 
I've accidentally found your repo. You have done a great job. I'm interested in using this parser in my nvim setup.
I think you parser is worthy to become default one for tree-sitter at some point.

I'm proposing small updates to make highlights closer to what already done in javascript:
- add highlight for "m" keyword
- update brackets highlights

Here is a screenshot how it looks like on my end now:
![Screenshot_20250412_133018](https://github.com/user-attachments/assets/e7316eb6-6cd9-45fa-b156-1a607ca87732)
