### PR TITLE
add README and WASM build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# tree-sitter-brightscript
+
+A tree-sitter grammar for BrightScript, the scripting language used in Roku development.
+
+## Features
+
+- Syntax highlighting for BrightScript (.brs) files
+- Support for folding, indents, and text objects
+- Compatible with editors that support tree-sitter grammars
+
+## Installation
+
+1. Clone this repo
+2. Node version greater than 18 is requored (24.4.0 confirmed working but lower might also work)
+
+
+### Helix Editor
+
+1. **Install dependencies**:
+   ```bash
+   npm install
+   ```
+
+2. **Generate the parser**:
+   ```bash
+   npx tree-sitter generate
+   ```
+
+3. **Build the WASM grammar**:
+   ```bash
+   npx tree-sitter build --wasm
+   ```
+
+4. **Create runtime directories**:
+   ```bash
+   mkdir -p ~/.config/helix/runtime/grammars ~/.config/helix/runtime/queries/brightscript
+   ```
+
+5. **Copy grammar and query files**:
+   ```bash
+   cp tree-sitter-brightscript.wasm ~/.config/helix/runtime/grammars/
+   cp queries/*.scm ~/.config/helix/runtime/queries/brightscript/
+   ```
+
+6. **Configure language support** (add to `~/.config/helix/languages.toml`):
+   ```toml
+   [language-server.brighterscript-lsp]
+   command = "bsc"
+   args = ["--lsp"]
+
+   [[language]]
+   name = "brightscript"
+   scope = "source.brightscript"
+   injection-regex = "brightscript"
+   file-types = ["brs", "bs"]
+   comment-tokens = ["'", "rem"]
+   indent = { tab-width = 4, unit = "    " }
+   language-servers = ["brighterscript-lsp"]
+   ```
+
+7. **Verify installation**:
+   ```bash
+   hx --health | grep brightscript
+   ```
+   You should see checkmarks (✓) for Highlight, Textobjects, and Indent.
+
+### Other Editors
+
+This grammar can be used with any editor that supports tree-sitter. Follow your editor's documentation for installing tree-sitter grammars.
+
+## Query Files
+
+The repository includes query files for:
+- `highlights.scm` - Syntax highlighting
+- `folds.scm` - Code folding
+- `indents.scm` - Automatic indentation
+- `injections.scm` - Language injections
+- `textobjects.scm` - Text object selection
+
+## Language Server
+
+For enhanced language features, you can use the BrighterScript Language Server:
+```bash
+npm install -g brighterscript
+```
+
+## Development
+
+To contribute to this grammar:
+
+1. Modify `grammar.js` to add or change language rules
+2. Run `npx tree-sitter generate` to regenerate the parser
+3. Test with `npx tree-sitter parse example.brs`
+4. Update query files as needed
+
+## License
+
+[License information would go here]

--- a/docs/wasm-build-process.md
+++ b/docs/wasm-build-process.md
@@ -1,0 +1,70 @@
+# WebAssembly Build Process
+
+The WASM (WebAssembly) steps are necessary because Helix editor uses WebAssembly modules to run tree-sitter grammars, rather than native shared libraries.
+
+## Why WASM?
+
+Helix chose WebAssembly because it provides:
+- **Sandboxing**: WASM runs in a secure, isolated environment
+- **Performance**: Near-native speed for parsing
+- **Portability**: Same binary works across different platforms
+- **Safety**: Memory-safe execution environment
+
+## The Build Process
+
+When you run `npx tree-sitter build --wasm`:
+
+1. **Docker Container**: It pulls the `emscripten/emsdk:3.1.55` Docker image, which contains the Emscripten compiler toolchain for converting C/C++ to WebAssembly
+
+2. **C Code Compilation**: The tree-sitter parser (written in C) from `src/parser.c` gets compiled to WebAssembly bytecode instead of native machine code
+
+3. **WASM Output**: Creates `tree-sitter-brightscript.wasm` - a WebAssembly module containing the compiled parser
+
+## What Helix Does With It
+
+When you place the `.wasm` file in `~/.config/helix/runtime/grammars/`:
+
+- Helix loads the WASM module at runtime
+- It instantiates the WebAssembly module in its WASM runtime
+- The parser runs inside this sandboxed environment
+- Query files (`.scm`) tell Helix how to use the parser output for syntax highlighting
+
+## Alternative Approaches
+
+Other editors might use:
+- **Shared libraries** (`.so`, `.dylib`, `.dll`) - native compiled code
+- **Node.js bindings** - for editors built on Electron
+- **Direct integration** - editors with built-in tree-sitter support
+
+The WASM approach is Helix's design choice for security and consistency across platforms.
+
+## File Structure After Build
+
+```
+tree-sitter-brightscript/
+├── src/
+│   └── parser.c                    # Generated C parser code
+├── queries/
+│   ├── highlights.scm              # Syntax highlighting queries
+│   ├── folds.scm                   # Code folding queries
+│   ├── indents.scm                 # Indentation queries
+│   ├── injections.scm              # Language injection queries
+│   └── textobjects.scm             # Text object queries
+└── tree-sitter-brightscript.wasm   # Compiled WASM module
+```
+
+## Installation Path
+
+The WASM file and queries are copied to:
+```
+~/.config/helix/runtime/
+├── grammars/
+│   └── tree-sitter-brightscript.wasm
+└── queries/
+    └── brightscript/
+        ├── highlights.scm
+        ├── folds.scm
+        ├── indents.scm
+        ├── injections.scm
+        └── textobjects.scm
+```


### PR DESCRIPTION
- Add comprehensive README.md with Helix installation instructions
- Add docs/wasm-build-process.md explaining WebAssembly build process
- Include language server configuration and verification steps

---

I'm not seeing syntax highlighting as expected yet, but:

```
hx --health brightscript
Configured language servers:
  ✓ bsc: /Users/alyssa.evans/.nvm/versions/node/v18.17.0/bin/bsc
Configured debug adapter: None
Configured formatter: None
Tree-sitter parser: None
Highlight queries: ✓
Textobject queries: ✓
Indent queries: ✓
```