### PR TITLE
m keyword detection and highlighting added

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -518,7 +518,9 @@ module.exports = grammar({
     _new_line: $ => /\r?\n/,
 
     // Miscellaneous
-    identifier: $ => token(prec(0, /[a-zA-Z_][a-zA-Z0-9_]*/))
+    identifier: $ => choice($.m, $.regular_identifier),
+    m: $ => /m/i,
+    regular_identifier: $ => token(prec(0, /[a-zA-Z_][a-zA-Z0-9_]*/)),
   }
 });
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -175,3 +175,4 @@
   ] @operator)
 
 (as) @keyword.operator
+(m) @keyword


### PR DESCRIPTION
Hi. Thanks for all of your work on this parser.
As I see it's already an official brightscript parser for tree-sitter. Congrats.
I suggest to add "m" keyword highlighting, like "this" in JS/TS.
<img width="299" height="220" alt="image" src="https://github.com/user-attachments/assets/eae0f4df-07ef-475f-8a48-34a02740e80f" />
